### PR TITLE
Fix/map initialization

### DIFF
--- a/src/map-provider.tsx
+++ b/src/map-provider.tsx
@@ -89,7 +89,7 @@ const GoogleMapProvider = (props: GoogleMapProviderProps): JSX.Element => {
 
   // Destroy and recreate map on language or region change
   useEffect(() => {
-    if (!map || !mapContainer) {
+    if (!map) {
       return;
     }
 


### PR DESCRIPTION
Map was not loading due to early exiting in useEffect hook.

First render: mapContainer is always `null` -> no init maps hook (early exit)
After that: The useEffect that is called when mapContainer changes requires a `map` (which should have been created in the init hook, which never happened)

I now combined those two hooks.

closes #14 