### PR TITLE
Updating README example to have initial center

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,17 @@ If you still can't see a map on your page, make sure that your `<MapCanvas>` com
 import React, { useState, useCallback, forwardRef } from 'react';
 import { GoogleMapProvider } from '@ubilabs/google-maps-react-hooks';
 
-const MapCanvas = React.forwardRef((props, ref) => (
-  <div ref={ref} />
+const MapCanvas = forwardRef((props, ref) => (
+  <div ref={ref} style={{ height: "100vh" }} />
 ));
+
+const mapOptions = {
+  zoom: 4,
+  center: {
+    lat: 40,
+    lng: -88,
+  },
+};
 
 function App() {
   const [mapContainer, setMapContainer] = useState(null);


### PR DESCRIPTION
It took me quite a while to realize that my screen was completely white because I had forgotten to pass an initial zoom and center location which seem to be required for the map to work correctly.

The example was missing the `mapOptions` variable so I added it in, and also took use of the imported `forwardRef` function rather than accessing it off of `React`.