### PR TITLE
Refactor/remove mapids map provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,6 @@ interface GoogleMapProviderProps {
   // By default Google Maps will use the preferred region from the browser setting. This is the property to set it manually, see: https://developers.google.com/maps/documentation/javascript/localization
   region?: string;
 
-  // Use this parameter for cloud-based map styling (in beta), see: https://developers.google.com/maps/documentation/javascript/cloud-based-map-styling
-  mapIds?: string[];
-
   // Use this parameter to specify a version, see: https://developers.google.com/maps/documentation/javascript/versions
   version?: string;
 

--- a/src/google-map.ts
+++ b/src/google-map.ts
@@ -10,7 +10,6 @@ interface GoogleMapOptions {
   libraries?: string[];
   language?: string;
   region?: string;
-  mapIds?: string[];
   version?: string;
 }
 
@@ -39,7 +38,6 @@ export default class GoogleMap {
 
     const {
       libraries,
-      mapIds,
       version,
       language,
       region,
@@ -54,7 +52,7 @@ export default class GoogleMap {
         language || defaultLanguage
       }&region=${region || defaultRegion}${
         libraries ? `&libraries=${libraries.join(',')}` : ''
-      }${mapIds ? `&map_ids=${mapIds.join(',')}` : ''}${
+      }${
         version ? `&v=${version}` : ''
       }`
     );

--- a/src/map-provider.tsx
+++ b/src/map-provider.tsx
@@ -9,7 +9,6 @@ export interface GoogleMapProviderProps {
   libraries?: string[];
   language?: string;
   region?: string;
-  mapIds?: string[];
   version?: string;
   onLoad?: (map: google.maps.Map) => void;
 }
@@ -29,7 +28,7 @@ export const GoogleMapContext = React.createContext<GoogleMapContextType>({
  * The global Google Map provider
  */
 const GoogleMapProvider: React.FunctionComponent<GoogleMapProviderProps> = (
-  props
+  props:{children: React.ReactNode} & GoogleMapProviderProps
 ) => {
   const {
     children,
@@ -39,7 +38,6 @@ const GoogleMapProvider: React.FunctionComponent<GoogleMapProviderProps> = (
     libraries,
     language,
     region,
-    mapIds,
     version,
     onLoad
   } = props;
@@ -64,7 +62,6 @@ const GoogleMapProvider: React.FunctionComponent<GoogleMapProviderProps> = (
       },
       config: options,
       libraries,
-      mapIds,
       language,
       region,
       version

--- a/src/map-provider.tsx
+++ b/src/map-provider.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, PropsWithChildren} from 'react';
 
 import GoogleMap from './google-map';
 
@@ -27,8 +27,8 @@ export const GoogleMapContext = React.createContext<GoogleMapContextType>({
 /**
  * The global Google Map provider
  */
-const GoogleMapProvider: React.FunctionComponent<GoogleMapProviderProps> = (
-  props:{children: React.ReactNode} & GoogleMapProviderProps
+const GoogleMapProvider: React.FunctionComponent<PropsWithChildren<GoogleMapProviderProps>> = (
+  props
 ) => {
   const {
     children,


### PR DESCRIPTION
Removes `mapIds` in `GoogleMapProviderProps` as it is no longer needed for cloud-based map styling.