### PR TITLE
feat(examples): add autocomplete places search example

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "clean-examples": "rm -rf public .parcel-cache",
     "start:map": "PARCEL_AUTOINSTALL=false parcel serve ./basic-google-map/index.html --dist-dir public --port 1234",
-    "start:map-markers": "PARCEL_AUTOINSTALL=false parcel serve ./google-map-with-markers/index.html --dist-dir public --port 1234"
+    "start:map-markers": "PARCEL_AUTOINSTALL=false parcel serve ./google-map-with-markers/index.html --dist-dir public --port 1234",
+    "start:autocomplete": "PARCEL_AUTOINSTALL=false parcel serve ./places-autocomplete/index.html --dist-dir public --port 1234"
   },
   "license": "MIT",
   "dependencies": {

--- a/examples/places-autocomplete/README.md
+++ b/examples/places-autocomplete/README.md
@@ -6,7 +6,15 @@ This is an example setup of a **Map with a Places Autocomplete Search** to show 
 
 To run this project, clone the Google Maps React Hooks repository locally.
 
-At the root of the repository, run:
+First go to the root of the repository and run:
+
+```shell
+npm install
+````
+
+once to install all dependencies.
+
+Then start this example locally with
 
 ```shell
 npm run start:autocomplete-example

--- a/examples/places-autocomplete/README.md
+++ b/examples/places-autocomplete/README.md
@@ -1,0 +1,28 @@
+# Basic Google Maps Setup Example
+
+This is an example setup of a **Map with a Places Autocomplete Search** to show the usage of the **useAutocomplete hook** with the Google Maps React Hooks library.
+
+## Instructions
+
+To run this project, clone the Google Maps React Hooks repository locally.
+
+At the root of the repository, run:
+
+```shell
+npm run start:autocomplete-example
+```
+
+**NOTE**:
+To see the examples it is needed to add an `.env` file with a [Google Maps API key](https://developers.google.com/maps/documentation/embed/get-api-key#:~:text=Go%20to%20the%20Google%20Maps%20Platform%20%3E%20Credentials%20page.&text=On%20the%20Credentials%20page%2C%20click,Click%20Close.) in the following format:
+
+`GOOGLE_MAPS_API_KEY="<YOUR API KEY HERE>"`
+
+An example can be found in `.env.example`.
+
+## Output
+
+The project will start at [localhost:1234](http://localhost:1234) and show a map with an input field and an autocomplete functionality.
+
+![image](https://user-images.githubusercontent.com/39244966/196221028-34d47ae1-b612-4886-bd51-f736ffb77197.png)
+
+![image](https://user-images.githubusercontent.com/39244966/196220079-22405c58-c364-48bf-b70c-dc828e4bd635.png)

--- a/examples/places-autocomplete/app.tsx
+++ b/examples/places-autocomplete/app.tsx
@@ -1,0 +1,46 @@
+import React, {FunctionComponent, useState, useCallback} from 'react';
+import {GoogleMapProvider} from '@ubilabs/google-maps-react-hooks';
+
+import MapCanvas from './components/map-canvas/map-canvas';
+import PlacesSearch from './components/places-search/places-search';
+
+import {GOOGLE_MAPS_API_KEY} from '../constants';
+
+import './main.module.css';
+
+const mapOptions = {
+  center: {lat: 53.5582447, lng: 9.647645},
+  zoom: 6,
+  disableDefaultUI: true,
+  zoomControl: true
+};
+
+const App: FunctionComponent<Record<string, unknown>> = () => {
+  const [mapContainer, setMapContainer] = useState<HTMLDivElement | null>(null);
+
+  const mapRef = useCallback(
+    (node: React.SetStateAction<HTMLDivElement | null>) => {
+      node && setMapContainer(node);
+    },
+    []
+  );
+
+  return (
+    <React.StrictMode>
+      <GoogleMapProvider
+        googleMapsAPIKey={GOOGLE_MAPS_API_KEY}
+        mapContainer={mapContainer}
+        options={mapOptions}
+        // Add the places library
+        libraries={['places']}
+      >
+        <div id="container">
+          <MapCanvas ref={mapRef} />
+          <PlacesSearch />
+        </div>
+      </GoogleMapProvider>
+    </React.StrictMode>
+  );
+};
+
+export default App;

--- a/examples/places-autocomplete/components/map-canvas/map-canvas.module.css
+++ b/examples/places-autocomplete/components/map-canvas/map-canvas.module.css
@@ -1,0 +1,4 @@
+.map {
+  width: 100%;
+  height: 100%;
+}

--- a/examples/places-autocomplete/components/map-canvas/map-canvas.tsx
+++ b/examples/places-autocomplete/components/map-canvas/map-canvas.tsx
@@ -1,0 +1,9 @@
+import React, {forwardRef} from 'react';
+
+import styles from './map-canvas.module.css';
+
+const MapCanvas = forwardRef<HTMLDivElement, Record<string, unknown>>(
+  (_, ref) => <div ref={ref} className={styles.map} />
+);
+
+export default MapCanvas;

--- a/examples/places-autocomplete/components/places-search/places-search.module.css
+++ b/examples/places-autocomplete/components/places-search/places-search.module.css
@@ -1,0 +1,8 @@
+.searchInput {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 20rem;
+  height: 2rem;
+  padding-left: 0.5rem;
+}

--- a/examples/places-autocomplete/components/places-search/places-search.tsx
+++ b/examples/places-autocomplete/components/places-search/places-search.tsx
@@ -1,0 +1,68 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {useAutocomplete, useGoogleMap} from '@ubilabs/google-maps-react-hooks';
+
+import styles from './places-search.module.css';
+
+const PlacesSearch = () => {
+  const {map} = useGoogleMap();
+
+  // Use the input ref to pass an input field to the useAutocomplete hook below
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [inputValue, setInputValue] = useState('');
+  const [selectedPlace, setSelectedPlace] =
+    useState<google.maps.places.PlaceResult | null>(null);
+
+  const [marker, setMarker] = useState<google.maps.Marker | null>(null);
+
+  const onPlaceChanged = (place: google.maps.places.PlaceResult) => {
+    if (place) {
+      setSelectedPlace(place);
+      setInputValue(place.formatted_address || place.name);
+
+      // Keep focus on input element
+      inputRef.current?.focus();
+    }
+  };
+
+  // Use the useAutocomplete hook and pass the input field ref and the onPlaceChanged function to it
+  useAutocomplete({
+    inputField: inputRef && inputRef.current,
+    onPlaceChanged
+  });
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+  };
+
+  useEffect(() => {
+    if (map && selectedPlace) {
+      if (marker) {
+        marker.setMap(null);
+      }
+
+      const markerOptions: google.maps.MarkerOptions = {
+        map,
+        position: selectedPlace?.geometry?.location,
+        title: selectedPlace.name,
+        clickable: false
+      };
+
+      // Add a marker whenever a place was selected
+      const newMarker = new google.maps.Marker(markerOptions);
+
+      setMarker(newMarker);
+    }
+  }, [map, selectedPlace]);
+
+  return (
+    <input
+      className={styles.searchInput}
+      ref={inputRef}
+      value={inputValue}
+      onChange={handleInputChange}
+    />
+  );
+};
+
+export default PlacesSearch;

--- a/examples/places-autocomplete/index.html
+++ b/examples/places-autocomplete/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de-DE">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no"
+    />
+    <title>
+      Example Google Map with a places search to show the usage of the
+      useAutocomplete hook of the Google Maps React Hooks.
+    </title>
+    <meta
+      name="description"
+      content="Example Google Map with a places search to show the usage of the useAutocomplete hook of the Google Maps React Hooks."
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/examples/places-autocomplete/index.tsx
+++ b/examples/places-autocomplete/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import App from './app';
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/examples/places-autocomplete/main.module.css
+++ b/examples/places-autocomplete/main.module.css
@@ -1,0 +1,9 @@
+html,
+body,
+:global(#app),
+:global(#container) {
+  height: 100vh;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postversion": "git push -u origin chore/release-${npm_package_version} && git push --tags --no-verify",
     "start:sample-map": "cd examples && npm run clean-examples && npm i && npm run start:map",
     "start:map-with-markers": "cd examples && npm run clean-examples && npm i && npm run start:map-markers",
-    "start:autocomplete-example": "cd examples && npm run clean-examples && npm i && npm run start:autocomplete",
+    "start:autocomplete-example": "cd examples && npm run clean-examples && npm run start:autocomplete",
     "start:geocoding-example": "cd examples && npm run clean-examples && npm i && npm run start:geocoding"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "version": "npm run changelog && git checkout -b chore/release-${npm_package_version} && git add .",
     "postversion": "git push -u origin chore/release-${npm_package_version} && git push --tags --no-verify",
     "start:sample-map": "cd examples && npm run clean-examples && npm i && npm run start:map",
-    "start:map-with-markers": "cd examples && npm run clean-examples && npm i && npm run start:map-markers"
+    "start:map-with-markers": "cd examples && npm run clean-examples && npm i && npm run start:map-markers",
+    "start:autocomplete-example": "cd examples && npm run clean-examples && npm i && npm run start:autocomplete"
   },
   "keywords": [
     "React hooks",


### PR DESCRIPTION
Adds an example to show how to use the `useAutocomplete` hook.