### PR TITLE
feat(hooks): add autocomplete-service hook

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -20,6 +20,7 @@ This is a JavaScript library to easily implement a Google Maps map into your Rea
     - [useMaxZoomService](https://github.com/ubilabs/google-maps-react-hooks/tree/main/library/docs/useMaxZoomService.md)
     - [usePlacesService](https://github.com/ubilabs/google-maps-react-hooks/tree/main/library/docs/usePlacesService.md)
     - [useAutocomplete](https://github.com/ubilabs/google-maps-react-hooks/tree/main/library/docs/useAutocomplete.md)
+    - [useAutocompleteService](https://github.com/ubilabs/google-maps-react-hooks/tree/main/library/docs/useAutocompleteService.md)
 - [Examples](https://github.com/ubilabs/google-maps-react-hooks/tree/main/examples)
   - [Basic Google Map](https://github.com/ubilabs/google-maps-react-hooks/tree/main/examples/basic-google-map)
   - [Google Map with Markers](https://github.com/ubilabs/google-maps-react-hooks/tree/main/examples/google-map-with-markers)

--- a/library/docs/useAutocomplete.md
+++ b/library/docs/useAutocomplete.md
@@ -1,12 +1,12 @@
 # `useAutocomplete` Hook
 
-React hook to use the [Google Maps Places Autocomplete Service](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service) in any component.
+React hook to use the [Google Maps Places Autocomplete Widget](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete) in any component.
 
 ## Usage
 
 When initializing the `<GoogleMapProvider>`, include the places library like this: `libraries={['places']}`.
 
-```jsx
+```tsx
 import React, {useRef, useState} from 'react';
 import {useAutocomplete} from '@ubilabs/google-maps-react-hooks';
 

--- a/library/docs/useAutocompleteService.md
+++ b/library/docs/useAutocompleteService.md
@@ -1,0 +1,25 @@
+# `useAutocompleteService` Hook
+
+React hook to use the [Google Maps Places Autocomplete Service](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service) in any component.
+
+## Usage
+
+When initializing the `<GoogleMapProvider>`, include the places library like this: `libraries={['places']}`.
+
+```tsx
+ // Code snippet here
+```
+
+## Methods
+
+There are two different [methods for Autocomplete Service](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService-Methods) to retrieve autocomplete predictions.
+
+1. [**getPlacePredictions**](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest): Gets place autocomplete predictions based on the supplied autocomplete request.
+
+2. [**getQueryPredictions**](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#QueryAutocompletionRequest): Gets place autocomplete predictions based on the supplied query autocomplete request.
+
+## Parameters
+
+### AutocompleteProps
+
+Needs a reference to an Input field, and has some optional properties. Check: [AutocompletionRequest interface](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest) or [QueryAutocompletionRequest interface](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#QueryAutocompletionRequest).

--- a/library/docs/useAutocompleteService.md
+++ b/library/docs/useAutocompleteService.md
@@ -10,14 +10,6 @@ When initializing the `<GoogleMapProvider>`, include the places library like thi
  // Code snippet here
 ```
 
-## Methods
-
-There are two different [methods for Autocomplete Service](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService-Methods) to retrieve autocomplete predictions.
-
-1. [**getPlacePredictions**](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest): Gets place autocomplete predictions based on the supplied autocomplete request.
-
-2. [**getQueryPredictions**](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#QueryAutocompletionRequest): Gets place autocomplete predictions based on the supplied query autocomplete request.
-
 ## Parameters
 
 ### AutocompleteProps

--- a/library/src/hooks/autocomplete-service.ts
+++ b/library/src/hooks/autocomplete-service.ts
@@ -3,12 +3,12 @@ import {useMemo} from 'react';
 import {useGoogleMap} from './map-instance';
 
 /**
- * Hook to get Google Maps Places Service instance
+ * Hook to get Google Maps Autocomplete Service instance
  */
 export const useAutocompleteService = (): google.maps.places.AutocompleteService | null => {
   const {map} = useGoogleMap();
 
-  // Creates a Places Service instance
+  // Creates an Autocomplete Service instance
   const autocompleteService = useMemo<google.maps.places.AutocompleteService | null>(() => {
     // Wait for map to be initialized
     if (!map) {

--- a/library/src/hooks/autocomplete-service.ts
+++ b/library/src/hooks/autocomplete-service.ts
@@ -1,0 +1,28 @@
+import {useMemo} from 'react';
+
+import {useGoogleMap} from './map-instance';
+
+/**
+ * Hook to get Google Maps Places Service instance
+ */
+export const useAutocompleteService = (): google.maps.places.AutocompleteService | null => {
+  const {map} = useGoogleMap();
+
+  // Creates a Places Service instance
+  const autocompleteService = useMemo<google.maps.places.AutocompleteService | null>(() => {
+    // Wait for map to be initialized
+    if (!map) {
+      return null;
+    }
+
+    if (!google.maps.places) {
+      throw Error(
+        "Places library missing. Add 'places' to the libraries array of GoogleMapProvider."
+      );
+    }
+
+    return new google.maps.places.AutocompleteService();
+  }, [map]);
+
+  return autocompleteService;
+};

--- a/library/src/index.ts
+++ b/library/src/index.ts
@@ -1,4 +1,5 @@
 // codegen:start {preset: barrel, include: ./**/*, exclude: [./index.ts, ./types/*, ./google-map.ts]}
+export * from './hooks/autocomplete-service';
 export * from './hooks/autocomplete';
 export * from './hooks/directions';
 export * from './hooks/distance-matrix';


### PR DESCRIPTION
- Adds `autocomplete-service` hook

That's basically it for the hook, no? I think the rest, how to use the service, can be done in the example and explained in README 